### PR TITLE
Added new NULL literal plan to change null values in string type column to literal NULL.

### DIFF
--- a/focus_converter_base/focus_converter/conversion_functions/__init__.py
+++ b/focus_converter_base/focus_converter/conversion_functions/__init__.py
@@ -27,6 +27,9 @@ class STATIC_CONVERSION_TYPES(Enum):
     # allows setting static values
     ASSIGN_STATIC_VALUE = "static_value"
 
+    # allows setting static NULL literal where values are null as defined in FOCUS spec
+    CHANGE_NULL_VALUES_TO_LITERAL_NULL = "apply_null_literal"
+
 
 __all__ = [
     "STATIC_CONVERSION_TYPES",

--- a/focus_converter_base/focus_converter/conversion_functions/column_functions.py
+++ b/focus_converter_base/focus_converter/conversion_functions/column_functions.py
@@ -92,3 +92,14 @@ class ColumnFunctions:
             StaticValueConversionArgs.model_validate(plan.conversion_args)
         )
         return pl.lit(conversion_args.static_value).alias(column_alias)
+
+    @staticmethod
+    def convert_null_values_to_null_literal(
+        plan: ConversionPlan, column_alias
+    ) -> pl.col:
+        return (
+            pl.when(pl.col(plan.column).is_null())
+            .then(pl.lit("NULL"))
+            .otherwise(pl.col(plan.column))
+            .alias(column_alias)
+        )

--- a/focus_converter_base/focus_converter/converter.py
+++ b/focus_converter_base/focus_converter/converter.py
@@ -165,6 +165,15 @@ class FocusConverter:
                         plan=plan, column_alias=column_alias
                     )
                 )
+            elif (
+                plan.conversion_type
+                == STATIC_CONVERSION_TYPES.CHANGE_NULL_VALUES_TO_LITERAL_NULL
+            ):
+                column_exprs.append(
+                    ColumnFunctions.convert_null_values_to_null_literal(
+                        plan=plan, column_alias=column_alias
+                    )
+                )
             else:
                 raise NotImplementedError(
                     f"Plan: {plan.conversion_type} not implemented"

--- a/focus_converter_base/tests/converter_functions/test_null_values_to_null_literal_function.py
+++ b/focus_converter_base/tests/converter_functions/test_null_values_to_null_literal_function.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from uuid import uuid4
+
+import polars as pl
+
+from focus_converter.configs.base_config import ConversionPlan
+from focus_converter.conversion_functions import STATIC_CONVERSION_TYPES
+from focus_converter.converter import FocusConverter
+from focus_converter.models.focus_column_names import FocusColumnNames
+
+
+class TestNullValueToLiteral(TestCase):
+    def test_with_null_value(self):
+        plan_config = """
+        plan_name: sample
+        priority: 1
+        column: aws_product_code
+        conversion_type: apply_null_literal
+        focus_column: Region
+        """
+
+        test_plan = ConversionPlan(
+            plan_name="sample",
+            priority=1,
+            dimension_id=1,
+            column="aws_product_code",
+            conversion_type=STATIC_CONVERSION_TYPES.CHANGE_NULL_VALUES_TO_LITERAL_NULL,
+            focus_column=FocusColumnNames.PROVIDER,
+            config_file_name="D0001-S000.yaml",
+        )
+        sample_provider_name = str(uuid4())
+
+        focus_converter = FocusConverter(column_prefix=None)
+        focus_converter.plans = {sample_provider_name: [test_plan]}
+        focus_converter.prepare_horizontal_conversion_plan(
+            provider=sample_provider_name
+        )
+
+        lf = pl.DataFrame({"aws_product_code": [None, "123"]}).lazy()
+        lf = focus_converter.__process_lazy_frame__(lf=lf)
+        df = lf.collect()
+
+        self.assertEqual(df["Provider"][0], "NULL")
+        self.assertEqual(df["Provider"][1], "123")


### PR DESCRIPTION
Allows converting null values in a column to be converted to literal NULL, allowing compliance with FOCUS spec.

```yaml
        plan_name: sample
        priority: 1
        column: aws_product_code
        conversion_type: apply_null_literal
        focus_column: Region
```