### PR TITLE
Dependency fixes + readme edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Use `focus-converter list-providers` to see the other providers that are support
 
 1. Clone this repository.
 2. [Install Poetry] if you don't have it.
-3. Run the following shell snippet:
+3. [Install libmagic] if you don't have it.
+4. Run the following shell snippet:
 
 ```sh
 cd focus_converter_base/
@@ -62,6 +63,7 @@ We're excited to work together. Please see [CONTRIBUTING.md] for information on 
 
 [CONTRIBUTING.md]: CONTRIBUTING.md
 [Install Poetry]: https://python-poetry.org/docs/#installation
+[Install libmagic]: https://formulae.brew.sh/formula/libmagic
 [FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec]: https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec
 [Amazon Web Services]: https://github.com/finopsfoundation/focus_converters/tree/master/focus_converter_base/conversion_configs/aws
 [Google Cloud]: https://github.com/finopsfoundation/focus_converters/tree/master/focus_converter_base/conversion_configs/gcp

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ cd focus_converter_base/
 poetry install --only main --no-root
 ```
 
-From here, you can use `python -m focus_converter.main` as a substitute for running the pre-installed `focus-converter` script, and test any changes in your copy of the repository.
+
+Before using `python -m focus_converter.main` as a substitute for the pre-installed `focus-converter` script and testing repository changes, ensure to run the `poetry shell` command to set up the environment correctly.
 
 ## License
 

--- a/focus_converter_base/pyproject.toml
+++ b/focus_converter_base/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{ include = "focus_converter" }]
 
 [tool.poetry.dependencies]
-python = "^3.8.3"
+python = "^3.9"
 jupyterlab = "^4.0.5"
 polars = "^0.19.2"
 jupyter = "^1.0.0"

--- a/focus_converter_base/pyproject.toml
+++ b/focus_converter_base/pyproject.toml
@@ -24,6 +24,7 @@ tqdm = "^4.66.1"
 sqlglot = "^18.7.0"
 # TODO(joshk): Change this to ^1 after release of the validator.
 focus-spec-validator = ">=0.5.2.dev1,<0.6.0"
+pillow = "^10.1.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Hi,
1. PIL is used but not included in the dependency list:
<img width="1512" alt="Screenshot 2023-12-07 at 18 44 58" src="https://github.com/finopsfoundation/focus_converters/assets/32438043/ee1a39c1-24a3-4aa1-a91b-b9e9c78d1fc4">

2. libmagic is required
<img width="1495" alt="Screenshot 2023-12-07 at 18 44 10" src="https://github.com/finopsfoundation/focus_converters/assets/32438043/d1fdd83b-7bb4-4304-a51d-d0fc5bddeef5">

3. `poetry shell` needs to be executed before running `python -m focus_converter.main`

4. As the readme says, python3.9 + is supported, changing this made it easier to add pillow to the dependency list

Thanks!