### PR TITLE
fix(aws-cur): wrong aws cur column used on ChargeSubcategory calculation

### DIFF
--- a/focus_converter_base/focus_converter/conversion_configs/aws-cur/charge_sub_category_S001.yaml
+++ b/focus_converter_base/focus_converter/conversion_configs/aws-cur/charge_sub_category_S001.yaml
@@ -4,11 +4,11 @@ conversion_args:
     conditions:
         - WHEN ChargeType = 'Usage' AND "savingsPlan/SavingsPlanARN" is not null OR "reservation/ReservationARN" is not null THEN 'Used Commitment'
         - WHEN ChargeType = 'Usage' THEN 'On-Demand'
-        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemDescription" = 'BundledDiscount' THEN 'Credit'
-        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemDescription" = 'Credit' THEN 'Credit'
-        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemDescription" = 'Discount' THEN 'Credit'
-        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemDescription" = 'DiscountedUsage' THEN 'Credit'
-        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemDescription" = 'Refund' THEN 'Refund'
+        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemType" = 'BundledDiscount' THEN 'Credit'
+        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemType" = 'Credit' THEN 'Credit'
+        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemType" = 'Discount' THEN 'Credit'
+        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemType" = 'DiscountedUsage' THEN 'Credit'
+        - WHEN ChargeType = 'Adjustment' AND "lineItem/LineItemType" = 'Refund' THEN 'Refund'
         - WHEN ChargeType = 'Adjustment' THEN 'General Adjustment'
     default_value: "NULL"
 column: NA


### PR DESCRIPTION
AWS CUR field that has a set of values contained on SQL comparison is [`lineItem/LineItemType`](https://docs.aws.amazon.com/cur/latest/userguide/Lineitem-columns.html#Lineitem-details-L).

Also, parquet converter plan uses `line_item_line_item_type` - the `lineItem/LineItemType` counterpart at AWS CUR CSV format.