### PR TITLE
fix(aws-cur): wrong invoice issuer field calculation

### DIFF
--- a/focus_converter_base/focus_converter/conversion_configs/aws-cur/invoice_issuer_S001.yaml
+++ b/focus_converter_base/focus_converter/conversion_configs/aws-cur/invoice_issuer_S001.yaml
@@ -1,4 +1,4 @@
 plan_name: convert bill_invoicing_entity to InvoiceIssuer
 conversion_type: rename_column
-column: bill/BillingEntity
+column: bill/InvoicingEntity
 focus_column: InvoiceIssuer


### PR DESCRIPTION
Parquet converter plan uses `bill_invoicing_entity`, and `bill/InvoicingEntity` is the correct counterpart at AWS CUR CSV format.