### PR TITLE
Fix aws-cur - parse bill/PayerAccountId as string

### DIFF
--- a/focus_converter_base/focus_converter/conversion_configs/aws-cur/0_dimension_dtypes_S001.yaml
+++ b/focus_converter_base/focus_converter/conversion_configs/aws-cur/0_dimension_dtypes_S001.yaml
@@ -28,3 +28,5 @@ conversion_args:
             dtype: datetime
         -   column_name: lineItem/UsageStartDate
             dtype: datetime
+        -   column_name: bill/PayerAccountId
+            dtype: string


### PR DESCRIPTION
 Column bill/PayerAccountId in AWS cur is getting parsed as an integer. To force parse it as per string(as per the defined in the FOCUS spec) I added this in the rule.