### PR TITLE
fix(aws): Region column source

### DIFF
--- a/focus_converter_base/focus_converter/conversion_configs/aws/3_region_S001.yaml
+++ b/focus_converter_base/focus_converter/conversion_configs/aws/3_region_S001.yaml
@@ -1,0 +1,6 @@
+plan_name: add default value to product_region if not present in CUR dataset
+conversion_type: apply_default_if_column_missing
+column: product_region
+focus_column: PlaceHolder
+conversion_args:
+    data_type: string

--- a/focus_converter_base/focus_converter/conversion_configs/aws/region_S001.yaml
+++ b/focus_converter_base/focus_converter/conversion_configs/aws/region_S001.yaml
@@ -1,4 +1,9 @@
 plan_name: convert product_region to Region
-conversion_type: rename_column
-column: product_region
+conversion_type: sql_condition
+conversion_args:
+    conditions:
+        - WHEN product_region is not null THEN product_region
+        - WHEN product_region_code is not null THEN product_region_code
+    default_value: "null"
+column: NA
 focus_column: Region


### PR DESCRIPTION
`product_region_code` and `product_region` in legacy AWS format have [same meaning](https://docs.aws.amazon.com/cur/latest/userguide/product-columns.html#product-details-R), but one or other is filled depending on AWS service.

Also, in CUR 2.0, just `product_region_code` is sent.

This PR is meant to fix those two conditions