### PR TITLE
Output specific parquet filename

### DIFF
--- a/focus_converter_base/focus_converter/converter.py
+++ b/focus_converter_base/focus_converter/converter.py
@@ -67,7 +67,9 @@ class FocusConverter:
 
     __basename_template__: Optional[str] = None
 
-    def __init__(self, column_prefix=None, converted_column_prefix=None, basename_template=None):
+    def __init__(
+        self, column_prefix=None, converted_column_prefix=None, basename_template=None
+    ):
         self.__temporary_columns__ = []
         self.__column_prefix__ = column_prefix
         self.__converted_column_prefix__ = converted_column_prefix
@@ -80,7 +82,6 @@ class FocusConverter:
         self.__deferred_column_plans__ = DeferredColumnFunctions()
 
         self.__basename_template__ = basename_template
-
 
     def load_provider_conversion_configs(self):
         plans = {}

--- a/focus_converter_base/focus_converter/converter.py
+++ b/focus_converter_base/focus_converter/converter.py
@@ -65,7 +65,9 @@ class FocusConverter:
     # converted column prefix to be added to converted columns
     __converted_column_prefix__: Optional[str] = None
 
-    def __init__(self, column_prefix=None, converted_column_prefix=None):
+    __basename_template__: Optional[str] = None
+
+    def __init__(self, column_prefix=None, converted_column_prefix=None, basename_template=None):
         self.__temporary_columns__ = []
         self.__column_prefix__ = column_prefix
         self.__converted_column_prefix__ = converted_column_prefix
@@ -76,6 +78,9 @@ class FocusConverter:
 
         # deferred column plans, these plans are applied after lazyframe is loaded
         self.__deferred_column_plans__ = DeferredColumnFunctions()
+
+        self.__basename_template__ = basename_template
+
 
     def load_provider_conversion_configs(self):
         plans = {}

--- a/focus_converter_base/focus_converter/data_loaders/data_exporter.py
+++ b/focus_converter_base/focus_converter/data_loaders/data_exporter.py
@@ -37,8 +37,8 @@ class DataExporter:
     ):
         self.__export_path__ = export_path
         self.__export_include_source_columns__ = export_include_source_columns
-        if basename_template and not re.search(r'-{i}\.parquet$', basename_template):
-            basename_template += '-{i}.parquet'
+        if basename_template and not re.search(r"-{i}\.parquet$", basename_template):
+            basename_template += "-{i}.parquet"
         self.__basename_template__ = basename_template
         self.__queue__ = queue = multiprocessing.Queue(maxsize=process_count)
 

--- a/focus_converter_base/focus_converter/data_loaders/data_exporter.py
+++ b/focus_converter_base/focus_converter/data_loaders/data_exporter.py
@@ -1,6 +1,6 @@
 import multiprocessing
-from queue import Empty
 import re
+from queue import Empty
 from typing import List
 
 import polars as pl

--- a/focus_converter_base/focus_converter/data_loaders/data_exporter.py
+++ b/focus_converter_base/focus_converter/data_loaders/data_exporter.py
@@ -6,7 +6,9 @@ import polars as pl
 import pyarrow.parquet as pq
 
 
-def __writer_process__(export_path, queue: multiprocessing.Queue, basename_template: str):
+def __writer_process__(
+    export_path, queue: multiprocessing.Queue, basename_template: str
+):
     while True:
         try:
             df = queue.get(timeout=0.1)
@@ -18,8 +20,9 @@ def __writer_process__(export_path, queue: multiprocessing.Queue, basename_templ
 
         pq.write_to_dataset(
             root_path=export_path,
-            compression="snappy", table=df.to_arrow(),
-            basename_template=basename_template
+            compression="snappy",
+            table=df.to_arrow(),
+            basename_template=basename_template,
         )
 
 
@@ -43,7 +46,7 @@ class DataExporter:
                 kwargs={
                     "queue": queue,
                     "export_path": self.__export_path__,
-                    "basename_template": self.__basename_template__
+                    "basename_template": self.__basename_template__,
                 },
             )
             processes.append(p)

--- a/focus_converter_base/focus_converter/data_loaders/data_exporter.py
+++ b/focus_converter_base/focus_converter/data_loaders/data_exporter.py
@@ -1,5 +1,6 @@
 import multiprocessing
 from queue import Empty
+import re
 from typing import List
 
 import polars as pl
@@ -36,6 +37,8 @@ class DataExporter:
     ):
         self.__export_path__ = export_path
         self.__export_include_source_columns__ = export_include_source_columns
+        if basename_template and not re.search(r'-{i}\.parquet$', basename_template):
+            basename_template += '-{i}.parquet'
         self.__basename_template__ = basename_template
         self.__queue__ = queue = multiprocessing.Queue(maxsize=process_count)
 

--- a/focus_converter_base/focus_converter/main.py
+++ b/focus_converter_base/focus_converter/main.py
@@ -54,6 +54,13 @@ def main_auto(
             rich_help_panel="Validation",
         ),
     ] = False,
+    basename_template: Annotated[
+        str,
+        typer.Option(
+            help="Specify a template string for output filename as opposed to `guid-{i}`.",
+            rich_help_panel="Data Export",
+        ),
+    ] = None,
 ):
     provider_sensor = ProviderSensor(base_path=data_path)
     provider_sensor.load()
@@ -70,6 +77,7 @@ def main_auto(
     converter.configure_data_export(
         export_path=export_path,
         export_include_source_columns=export_include_source_columns,
+        basename_template=basename_template,
     )
     converter.prepare_horizontal_conversion_plan(provider=provider_sensor.provider)
     converter.convert()
@@ -116,6 +124,13 @@ def main(
             rich_help_panel="Validation",
         ),
     ] = False,
+    basename_template: Annotated[
+        str,
+        typer.Option(
+            help="Specify a template string for output filename as opposed to `guid-{i}`.",
+            rich_help_panel="Data Export",
+        ),
+    ] = None,
 ):
     # compute function for conversion
 
@@ -134,6 +149,7 @@ def main(
     converter.configure_data_export(
         export_path=export_path,
         export_include_source_columns=export_include_source_columns,
+        basename_template=basename_template,
     )
     converter.prepare_horizontal_conversion_plan(provider=provider)
     converter.convert()

--- a/focus_converter_base/focus_converter/main.py
+++ b/focus_converter_base/focus_converter/main.py
@@ -57,7 +57,7 @@ def main_auto(
     basename_template: Annotated[
         str,
         typer.Option(
-            help="Specify a template string for output filename as opposed to `guid-{i}`.",
+            help="Specify a template string for output filename as opposed to guid-{i}.",
             rich_help_panel="Data Export",
         ),
     ] = None,


### PR DESCRIPTION
Fixes Issue #338 by adding a new command line option to specify the name of the parquet file output by the converter tool